### PR TITLE
Shorten and fix docs/examples: normalize thoughts/ ticket names and command examples

### DIFF
--- a/agent/thoughts-locator.md
+++ b/agent/thoughts-locator.md
@@ -66,10 +66,10 @@ Structure your findings like this:
 - `thoughts/architecture/core-design.md - Namespace design`
 
 ### Tickets
-- `thoughts/tickets/eng_1234.md` - Implement rate limiting for API
+- `thoughts/tickets/feature-rate-limiting-api-123.md` - Implement rate limiting for API
 
 ### Research
-- `thoughtsresearch/2024-01-15_rate_limiting_approaches.md` - Research on different rate limiting strategies
+- `thoughts/research/2024-01-15_rate-limiting-approaches.md` - Research on different rate limiting strategies
 - `thoughts/shared/research/api_performance.md` - Contains section on rate limiting impact
 
 ### Implementation Plans

--- a/command/plan.md
+++ b/command/plan.md
@@ -11,7 +11,7 @@ You are tasked with creating detailed implementation plans through an interactiv
 ### Step 1: Context Gathering & Initial Analysis
 
 1. **Read all mentioned files immediately and FULLY**:
-   - Ticket files (e.g., `thoughts/tickets/eng_1234.md`)
+   - Ticket files (e.g., `thoughts/tickets/bug-login-validation-456.md`)
    - Research documents
    - Related implementation plans
    - Any JSON/data files mentioned

--- a/command/ticket.md
+++ b/command/ticket.md
@@ -128,7 +128,7 @@ Extract and organize information specifically for the research phase:
 - Security requirements
 
 ### Step 5: Ticket Creation
-Create the ticket file at: `thoughts/tickets/type_subject.md`
+Create the ticket file at: `thoughts/tickets/type-subject-number.md`
 
 Use this template structure:
 
@@ -137,6 +137,7 @@ Use this template structure:
 type: [bug|feature|debt]
 priority: [high|medium|low]
 created: [ISO date]
+created_by: [model-name-and-version]
 status: open
 tags: [relevant-tags]
 keywords: [comma-separated keywords for research]
@@ -233,11 +234,11 @@ Use the todowrite tool to create a structured task list for the 7 steps above, m
 - **Research-friendly**: Include specific hooks for research agents
 
 ### File Naming
-- Use format: `<type>_<subject>.md`
+- Use format: `<type>-<subject>-<number>.md`
 - Examples:
-  - `bug_login_validation.md`
-  - `feature_user_dashboard.md`
-  - `debt_auth_refactor.md`
+  - `bug-login-validation-001.md`
+  - `feature-user-dashboard-002.md`
+  - `debt-auth-refactor-003.md`
 
 ## Examples
 
@@ -247,7 +248,7 @@ Use the todowrite tool to create a structured task list for the 7 steps above, m
 type: bug
 priority: high
 created: 2025-01-15T10:30:00Z
-created_by: Opus
+created_by: Claude Opus 4.1
 status: open
 tags: [auth, login, validation]
 keywords: [login, validateCredentials, error message, authentication]
@@ -309,7 +310,7 @@ Clear error message displayed when credentials are invalid
 type: feature
 priority: medium
 created: 2025-01-15T14:20:00Z
-created_by: Opus
+created_by: Claude Opus 4.1
 status: open
 tags: [ui, dashboard, analytics]
 keywords: [dashboard, analytics, chart, metrics]

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,7 +47,7 @@ Example:
 
 **Example**:
 ```
-/plan thoughts/tickets/eng-123.md thoughts/research/2025-01-15_oauth-research.md
+/plan thoughts/tickets/bug-login-validation-123.md thoughts/research/2025-01-15_oauth-research.md
 ```
 
 **Process**:
@@ -117,7 +117,7 @@ Example:
 4. Documents findings
 5. Provides recommendations
 
-**Output**: `thoughts/reviews/YYYY-MM-DD_review.md`
+**Output**: `thoughts/reviews/[ticket-filename]-review.md`
 
 ## Command Structure
 

--- a/docs/thoughts.md
+++ b/docs/thoughts.md
@@ -8,9 +8,9 @@ The `thoughts/` directory is your project's knowledge base, containing all docum
 
 ```
 thoughts/
-├── architecture/     # System design and decisions
-├── tickets/         # Work items and feature requests
-├── research/        # Analysis and findings
+├── architecture/   # System design and decisions
+├── tickets/        # Work items and feature requests
+├── research/       # Analysis and findings
 ├── plans/          # Implementation specifications
 ├── reviews/        # Post-implementation validation
 └── archive/        # Outdated documents (excluded from searches)
@@ -39,7 +39,7 @@ thoughts/
 
 **Purpose**: Track work items, issues, and feature requests.
 
-**File Format**: `[type]-[number].md` (e.g., `eng-123.md`, `bug-456.md`)
+**File Format**: `[type]-[subject]-[number].md` (e.g., `feature-user-dashboard-123.md`, `bug-login-validation-456.md`)
 
 **Content Structure**:
 ```markdown
@@ -106,7 +106,7 @@ Any relevant background information
 
 **Purpose**: Post-implementation validation and documentation.
 
-**File Format**: `YYYY-MM-DD_review.md`
+**File Format**: `[type]-[subject]-[number]-review.md`
 
 **Content Structure**:
 - Implementation summary


### PR DESCRIPTION
Quick cleanup: fixed a few typos and standardized examples across docs and command templates.

**What I changed**

- Normalized `ticket/research` filenames to kebab-case with a numeric suffix (e.g., bug-login-validation-001.md)
- Fixed broken/mis-typed example paths in  `agent/` and `docs/`
- Clarified `thoughts/` and `command/` templates (added `created_by` in examples, ensures consistency with the metadata)

**Why**
Makes examples consistent and less confusing for humans and agent tooling.

**Testing & impact**
Docs-only and minimal changes to commands and sub-agents declarations. Quick visual check of updated files recommended.