### PR TITLE
Update retired model IDs and drop sampling params Opus 4.7+ rejects

### DIFF
--- a/.github/workflows/opencode.yml
+++ b/.github/workflows/opencode.yml
@@ -24,4 +24,4 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          model: anthropic/claude-sonnet-4-20250514
+          model: anthropic/claude-sonnet-4-6

--- a/agent/codebase-analyzer.md
+++ b/agent/codebase-analyzer.md
@@ -1,8 +1,7 @@
 ---
 description: Analyzes codebase implementation details. Call the codebase-analyzer agent when you need to find detailed information about specific components.
 mode: subagent
-model: anthropic/claude-opus-4-1-20250805
-temperature: 0.1
+model: anthropic/claude-opus-4-8
 tools:
   read: true
   grep: true

--- a/agent/codebase-locator.md
+++ b/agent/codebase-locator.md
@@ -1,8 +1,7 @@
 ---
 description: Locates files, directories, and components relevant to a feature or task. Call `codebase-locator` with human language prompt describing what you're looking for. Basically a "Super Grep/Glob/LS tool" — Use it if you find yourself desiring to use one of these tools more than once.
 mode: subagent
-model: anthropic/claude-opus-4-1-20250805
-temperature: 0.1
+model: anthropic/claude-opus-4-8
 tools:
   read: false
   grep: true

--- a/agent/codebase-pattern-finder.md
+++ b/agent/codebase-pattern-finder.md
@@ -1,8 +1,7 @@
 ---
 description: codebase-pattern-finder is a useful subagent_type for finding similar implementations, usage examples, or existing patterns that can be modeled after. It will give you concrete code examples based on what you're looking for! It's sorta like codebase-locator, but it will not only tell you the location of files, it will also give you code details!
 mode: subagent
-model: anthropic/claude-opus-4-1-20250805
-temperature: 0.1
+model: anthropic/claude-opus-4-8
 tools:
   read: true
   grep: true

--- a/agent/thoughts-analyzer.md
+++ b/agent/thoughts-analyzer.md
@@ -1,8 +1,7 @@
 ---
 description: The research equivalent of codebase-analyzer. Use this subagent_type when wanting to deep dive on a research topic. Not commonly needed otherwise.
 mode: subagent
-model: anthropic/claude-opus-4-1-20250805
-temperature: 0.1
+model: anthropic/claude-opus-4-8
 tools:
   read: true
   grep: true

--- a/agent/thoughts-locator.md
+++ b/agent/thoughts-locator.md
@@ -1,8 +1,7 @@
 ---
 description: Discovers relevant documents in thoughts/ directory (We use this for all sorts of metadata storage!). This is really only relevant/needed when you're in a reseaching mood and need to figure out if we have random thoughts written down that are relevant to your current research task. Based on the name, I imagine you can guess this is the `thoughts` equivilent of `codebase-locator`
 mode: subagent
-model: anthropic/claude-opus-4-1-20250805
-temperature: 0.1
+model: anthropic/claude-opus-4-8
 tools:
   read: true
   grep: true

--- a/agent/web-search-researcher.md
+++ b/agent/web-search-researcher.md
@@ -1,7 +1,7 @@
 ---
 description: Used to perform web searches from a URL and analyze the contents based on a query.
 mode: subagent
-model: anthropic/claude-3-5-haiku-20241022
+model: anthropic/claude-haiku-4-5-20251001
 temperature: 0.1
 tools:
   read: true


### PR DESCRIPTION
Two things in the agent definitions stop working on current Claude models. Both are one-line fixes, but they interact, so this PR does them together.

### 1. Retired and expiring model IDs

| Current ID | Replaced with | Status | Retirement |
|---|---|---|---|
| `claude-opus-4-1-20250805` | `claude-opus-4-8` | deprecated | **5 August 2026** |
| `claude-3-5-haiku-20241022` | `claude-haiku-4-5-20251001` | retired | 19 February 2026 |
| `claude-sonnet-4-20250514` | `claude-sonnet-4-6` | retired | 15 June 2026 |

A retired ID does not fall back to a newer model, the API returns an error for it, so the two already-retired IDs fail today and `claude-opus-4-1-20250805` joins them on 5 August.

Replacements are the ones Anthropic recommends in its [deprecation table](https://platform.claude.com/docs/en/about-claude/model-deprecations).

### 2. `temperature` on the Opus agents

`temperature`, `top_p` and `top_k` return a **400 error** when set to a non-default value on Claude Opus 4.7 and later. Anthropic's migration guide puts it plainly:

> Setting `temperature`, `top_p`, or `top_k` to any non-default value on Claude Opus 4.7 or later models, including Claude Opus 5, returns a 400 error. The safest migration path is to omit these parameters entirely from request payloads.

So bumping the five Opus agents to `claude-opus-4-8` while they still carry `temperature: 0.1` would trade an expiring model for a hard 400. This PR removes that line from those five files only.

`agent/web-search-researcher.md` keeps its `temperature: 0.1`, because the restriction is documented for Opus 4.7+ and not for Haiku 4.5.

### Diff summary

- 5 Opus agents: model ID bumped, `temperature: 0.1` removed
- 1 Haiku agent: model ID bumped, temperature left alone
- `.github/workflows/opencode.yml`: model ID bumped

Nothing else changed. No logic, prompts, tool config, formatting or dependencies.

### Disclosure

I read this diff line by line before opening it, and I am happy to adjust or drop any part of it. What brought me here was a checker I maintain that flags retired Claude model IDs, so I am mentioning that up front rather than leaving you to wonder. If you would rather not get this kind of contribution, tell me and I will not send another.

