### PR TITLE
feat(cli): support custom OpenCode config directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,11 +47,32 @@ bun link  # Makes 'agentic' command available globally
 
 ### Deploy globally
 
-This will pull all agents/commands into your global `~/.config/opencode/` directory.
+This will pull all agents/commands into your global OpenCode config directory. By default this is `~/.config/opencode/`; if the `OPENCODE_CONFIG_DIR` environment variable is defined, that directory is used instead.
 
 ```bash
 agentic pull -g
 ```
+
+### Deploy to a custom config directory
+
+When OpenCode reads its configuration from a directory other than the global default, point agentic at it with `--config-dir`:
+
+```bash
+agentic pull --config-dir ~/.config/opencode/profiles/agentic
+agentic status --config-dir ~/.config/opencode/profiles/agentic
+```
+
+This is useful for:
+- OpenCode profile managers
+- Isolated configurations
+- Testing
+- Setups where OpenCode does not use the global config directory by default
+
+The config directory is resolved with the following precedence:
+
+1. `--config-dir` (explicit flag)
+2. `OPENCODE_CONFIG_DIR` (environment variable)
+3. `~/.config/opencode` (default)
 
 ### Deploy to Your Project
 

--- a/docs/agentic.md
+++ b/docs/agentic.md
@@ -16,7 +16,7 @@ bun link  # Makes 'agentic' available globally
 
 ### `agentic pull [project-path]`
 
-Pulls the latest agents and commands to a project's `.opencode` directory.
+Pulls the latest agents and commands to a project's `.opencode` directory, or to a global/custom OpenCode config directory with `-g`/`--config-dir`.
 
 **Usage:**
 ```bash
@@ -29,13 +29,21 @@ agentic pull ~/projects/my-app
 
 # Pull ignoring YAML frontmatter changes
 agentic pull --ignore-frontmatter
+
+# Pull to the global config directory
+agentic pull -g
+
+# Pull to a custom config directory
+agentic pull --config-dir ~/.config/opencode/profiles/agentic
 ```
 
 **Options:**
+- `-g, --global`: Pull to the global OpenCode config directory (resolved via `OPENCODE_CONFIG_DIR` or `~/.config/opencode`) instead of a project's `.opencode`
+- `--config-dir <path>`: Pull to a specific config directory, overriding the global default
 - `--ignore-frontmatter`: Ignore YAML frontmatter in Markdown (.md) files when comparing and preserve target frontmatter during pull
 
 **What it does:**
-- Creates `.opencode` directory if it doesn't exist
+- Creates the target directory if it doesn't exist
 - Copies all files from `agent/` and `command/` directories
 - Preserves directory structure
 - Reports progress for each file copied
@@ -44,14 +52,13 @@ agentic pull --ignore-frontmatter
 **Output:**
 ```
 📦 Pulling to: /home/user/projects/my-app/.opencode
-📁 Including: agent, command
 
-  ✓ Copied: agent/codebase-analyzer.md
-  ✓ Copied: agent/codebase-locator.md
-  ✓ Copied: command/research.md
-  ✓ Copied: command/plan.md
+📁 Found 3 file(s) to update
 
-✅ Pulled 10 files
+  ✓ Added: agent/codebase-analyzer.md
+  ✓ Updated: command/research.md
+
+✅ Updated 2 files
 ```
 
 ### `agentic status [project-path]`
@@ -69,13 +76,21 @@ agentic status ~/projects/my-app
 
 # Check status ignoring YAML frontmatter changes
 agentic status --ignore-frontmatter
+
+# Check status of the global config directory
+agentic status -g
+
+# Check status of a custom config directory
+agentic status --config-dir ~/.config/opencode/profiles/agentic
 ```
 
 **Options:**
+- `-g, --global`: Check the global OpenCode config directory (resolved via `OPENCODE_CONFIG_DIR` or `~/.config/opencode`) instead of a project's `.opencode`
+- `--config-dir <path>`: Check a specific config directory, overriding the global default
 - `--ignore-frontmatter`: Ignore YAML frontmatter in Markdown (.md) files when comparing
 
 **What it does:**
-- Compares files in `.opencode` with source repository
+- Compares files in `.opencode` (or the global/custom config directory) with source repository
 - Identifies missing, outdated, or extra files
 - Uses SHA-256 hashing for content comparison
 - When `--ignore-frontmatter` is used: treats files with only frontmatter changes as up-to-date
@@ -83,20 +98,18 @@ agentic status --ignore-frontmatter
 **Output:**
 ```
 📊 Status for: /home/user/projects/my-app/.opencode
-📁 Checking: agent, command
 
 ✅ agent/codebase-analyzer.md
-✅ agent/codebase-locator.md
-❌ command/research.md (outdated)
-❌ command/execute.md (missing in project)
+⚠️  command/research.md (outdated)
+❌ command/execute.md (missing)
 
 📋 Summary:
-  ✅ Up-to-date: 2
-  ❌ Outdated: 1
+  ✅ Up-to-date: 1
+  ⚠️  Outdated: 1
   ❌ Missing: 1
 
-⚠️  2 files need attention
-Run 'agentic pull' to update the project
+⚠️  2 files need updating
+Run 'agentic pull' to sync the files
 ```
 
 ### `agentic metadata`
@@ -150,6 +163,34 @@ agentic version
 agentic --version
 ```
 
+## Global and custom config directories
+
+By default, `pull` and `status` operate on a project's `.opencode` directory. Use `-g/--global` to operate on the global OpenCode config directory instead, or `--config-dir <path>` to target an explicit directory (for example, an OpenCode profile).
+
+The target config directory is resolved with the following precedence:
+
+1. `--config-dir <path>` — explicit flag, highest priority
+2. `OPENCODE_CONFIG_DIR` — environment variable, used when the global config lives somewhere other than the default
+3. `~/.config/opencode` — the default global location
+
+**Examples:**
+
+```bash
+# Global deployment (uses OPENCODE_CONFIG_DIR if defined, otherwise ~/.config/opencode)
+agentic pull -g
+agentic status -g
+
+# Custom config directory (e.g. an OpenCode profile)
+agentic pull --config-dir ~/.config/opencode/profiles/agentic
+agentic status --config-dir ~/.config/opencode/profiles/agentic
+```
+
+**Notes:**
+
+- `--config-dir` cannot be combined with a project path
+- When both `-g` and `--config-dir` are given, `--config-dir` takes precedence
+- `-g` and `--config-dir` bypass project auto-detection entirely
+
 ## Auto-detection
 
 The CLI uses intelligent project detection:
@@ -157,20 +198,31 @@ The CLI uses intelligent project detection:
 1. **With path argument**: Uses the provided path directly
 2. **Without argument**: Searches upward from current directory for `.opencode`
 3. **Stops at**: Home directory boundary (won't search outside `$HOME`)
+4. **With `-g`/`--config-dir`**: Bypasses detection and targets the global/custom config directory directly
 
 ## Configuration
 
-The CLI reads configuration from `config.json` in the agentic repository:
+Per-project configuration is read from `.opencode/agentic.json`:
 
 ```json
 {
-  "pull": {
-    "include": ["agent", "command"]
+  "thoughts": "thoughts",
+  "agents": {
+    "model": "opencode/grok-code"
   }
 }
 ```
 
-Currently, this specifies which directories to include when pulling.
+- `thoughts`: relative path to the project's thoughts directory (used by `init`)
+- `agents.model`: default agent model applied to agents during `pull` and `status`
+
+The agent model is resolved with the following priority:
+
+1. `--agent-model` (CLI flag)
+2. `agents.model` in `agentic.json`
+3. No model substitution
+
+The directories synced by `pull` and `status` (`agent` and `command`) are currently fixed in the source.
 
 ## Error Handling
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -86,7 +86,8 @@ Commands:
 
 Options:
   -h, --help             Show this help message
-  -g, --global           Use ~/.config/opencode instead of .opencode directory
+  -g, --global           Use the global OpenCode config directory (OPENCODE_CONFIG_DIR or ~/.config/opencode) instead of .opencode directory
+  --config-dir <path>    Use a custom config directory instead of the default global one
   --version              Show the version of agentic
   --thoughts-dir         Specify thoughts directory (for init command)
   --agent-model          Specify model for subagents (for status and pull commands)
@@ -97,10 +98,12 @@ Examples:
   agentic init ~/projects/my-app     # Initialize in specific project
   agentic pull ~/projects/my-app
   agentic pull                       # Auto-detect project from current dir
-  agentic pull -g                    # Pull to ~/.config/opencode
+  agentic pull -g                    # Pull to global config dir (OPENCODE_CONFIG_DIR or ~/.config/opencode)
+  agentic pull --config-dir ~/.config/opencode/profiles/agentic
   agentic status ~/projects/my-app
   agentic status                     # Auto-detect project from current dir
-  agentic status -g                  # Check status of ~/.config/opencode
+  agentic status -g                  # Check status of global config dir (OPENCODE_CONFIG_DIR or ~/.config/opencode)
+  agentic status --config-dir ~/.config/opencode/profiles/agentic
   agentic config                     # Show current configuration
   agentic config agent.model         # Show current agent model
   agentic config agent.model opus-4-1 # Set agent model to opus-4-1

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -39,6 +39,9 @@ try {
         type: "boolean",
         default: false,
       },
+      "config-dir": {
+        type: "string",
+      },
     },
     strict: true,
     allowPositionals: true,
@@ -120,9 +123,20 @@ switch (command) {
     }
 
     if (command === "pull") {
-      await pull(projectPath, values.global, values["agent-model"], values["ignore-frontmatter"]);
+      await pull(
+        projectPath,
+        values.global,
+        values["agent-model"],
+        values["ignore-frontmatter"],
+        values["config-path"],
+      );
     } else if (command === "status") {
-      await status(projectPath, values.global, values["agent-model"], values["ignore-frontmatter"]);
+      await status(
+        projectPath,
+        values.global,
+        values["agent-model"],
+        values["ignore-frontmatter"],
+      );
     }
     break;
   case "config":

--- a/src/cli/pull.ts
+++ b/src/cli/pull.ts
@@ -1,18 +1,27 @@
 import { mkdir, copyFile, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { existsSync } from "node:fs";
-import { resolveProjectPath, findOutOfSyncFiles, findAgenticInstallDir, processAgentTemplate, resolveAgentModel } from "./utils";
+import {
+  resolveProjectPath,
+  findOutOfSyncFiles,
+  findAgenticInstallDir,
+  processAgentTemplate,
+  resolveAgentModel,
+} from "./utils";
 
-function extractYamlFrontmatter(text: string): { frontmatter: string | null, body: string } {
-  if (!text.startsWith('---\n') && !text.startsWith('---\r\n')) {
+function extractYamlFrontmatter(text: string): {
+  frontmatter: string | null;
+  body: string;
+} {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
     return { frontmatter: null, body: text };
   }
 
-  const lines = text.split('\n');
+  const lines = text.split("\n");
   let endIndex = -1;
 
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i].trim() === '---') {
+    if (lines[i].trim() === "---") {
       endIndex = i;
       break;
     }
@@ -22,18 +31,21 @@ function extractYamlFrontmatter(text: string): { frontmatter: string | null, bod
     return { frontmatter: null, body: text };
   }
 
-  const frontmatter = lines.slice(0, endIndex + 1).join('\n');
-  const body = lines.slice(endIndex + 1).join('\n');
+  const frontmatter = lines.slice(0, endIndex + 1).join("\n");
+  const body = lines.slice(endIndex + 1).join("\n");
 
   return { frontmatter, body };
 }
 
-function mergeMdPreservingTargetFrontmatter(targetText: string, sourceText: string): string {
+function mergeMdPreservingTargetFrontmatter(
+  targetText: string,
+  sourceText: string,
+): string {
   const target = extractYamlFrontmatter(targetText);
   const source = extractYamlFrontmatter(sourceText);
 
   if (target.frontmatter) {
-    return target.frontmatter + '\n' + source.body;
+    return target.frontmatter + "\n" + source.body;
   } else {
     return source.body;
   }
@@ -44,9 +56,14 @@ export async function pull(
   useGlobal: boolean = false,
   agentModel?: string,
   ignoreFrontmatter: boolean = false,
+  configPath?: string,
 ) {
   // Resolve the project path (will exit if invalid)
-  const resolvedProjectPath = resolveProjectPath(projectPath, useGlobal);
+  const resolvedProjectPath = resolveProjectPath(
+    projectPath,
+    useGlobal,
+    configPath,
+  );
 
   // Determine target directory
   const targetBase = useGlobal
@@ -56,14 +73,24 @@ export async function pull(
   console.log(`📦 Pulling to: ${targetBase}`);
 
   // Resolve the agent model with proper priority
-  const resolvedModel = await resolveAgentModel(agentModel, resolvedProjectPath);
+  const resolvedModel = await resolveAgentModel(
+    agentModel,
+    resolvedProjectPath,
+  );
 
   // Find all out-of-sync files
-  const syncStatus = await findOutOfSyncFiles(targetBase, agentModel, resolvedProjectPath, ignoreFrontmatter);
+  const syncStatus = await findOutOfSyncFiles(
+    targetBase,
+    agentModel,
+    resolvedProjectPath,
+    ignoreFrontmatter,
+  );
   const sourceDir = findAgenticInstallDir();
 
   // Filter files that need action (only missing or outdated)
-  const filesToCopy = syncStatus.filter(f => f.status === 'missing' || f.status === 'outdated');
+  const filesToCopy = syncStatus.filter(
+    (f) => f.status === "missing" || f.status === "outdated",
+  );
 
   if (filesToCopy.length === 0) {
     console.log("\n✨ All files are already up-to-date!");
@@ -83,33 +110,46 @@ export async function pull(
       await mkdir(targetDir, { recursive: true });
     }
 
-    const isAgentMarkdown = file.path.startsWith('agent/') && file.path.endsWith('.md');
-    const isMarkdown = file.path.endsWith('.md');
+    const isAgentMarkdown =
+      file.path.startsWith("agent/") && file.path.endsWith(".md");
+    const isMarkdown = file.path.endsWith(".md");
 
     if (isAgentMarkdown) {
-      const sourceContent = await processAgentTemplate(sourceFile, resolvedModel);
-      if (file.status === 'missing') {
-        await writeFile(targetFile, sourceContent, 'utf-8');
-      } else if (ignoreFrontmatter && isMarkdown && file.status === 'outdated') {
+      const sourceContent = await processAgentTemplate(
+        sourceFile,
+        resolvedModel,
+      );
+      if (file.status === "missing") {
+        await writeFile(targetFile, sourceContent, "utf-8");
+      } else if (
+        ignoreFrontmatter &&
+        isMarkdown &&
+        file.status === "outdated"
+      ) {
         const targetText = await Bun.file(targetFile).text();
-        const merged = mergeMdPreservingTargetFrontmatter(targetText, sourceContent);
-        await writeFile(targetFile, merged, 'utf-8');
+        const merged = mergeMdPreservingTargetFrontmatter(
+          targetText,
+          sourceContent,
+        );
+        await writeFile(targetFile, merged, "utf-8");
       } else {
-        await writeFile(targetFile, sourceContent, 'utf-8');
+        await writeFile(targetFile, sourceContent, "utf-8");
       }
-    } else if (ignoreFrontmatter && isMarkdown && file.status === 'outdated') {
+    } else if (ignoreFrontmatter && isMarkdown && file.status === "outdated") {
       const sourceText = await Bun.file(sourceFile).text();
       const targetText = await Bun.file(targetFile).text();
       const merged = mergeMdPreservingTargetFrontmatter(targetText, sourceText);
-      await writeFile(targetFile, merged, 'utf-8');
+      await writeFile(targetFile, merged, "utf-8");
     } else {
       // Copy the file normally for missing files or non-md files
       await copyFile(sourceFile, targetFile);
     }
 
-    const action = file.status === 'missing' ? 'Added' : 'Updated';
+    const action = file.status === "missing" ? "Added" : "Updated";
     console.log(`  ✓ ${action}: ${file.path}`);
   }
 
-  console.log(`\n✅ Updated ${filesToCopy.length} file${filesToCopy.length === 1 ? "" : "s"}`);
+  console.log(
+    `\n✅ Updated ${filesToCopy.length} file${filesToCopy.length === 1 ? "" : "s"}`,
+  );
 }

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -12,7 +12,7 @@ interface AgenticConfig {
 
 export interface FileSync {
   path: string;
-  status: 'up-to-date' | 'outdated' | 'missing';
+  status: "up-to-date" | "outdated" | "missing";
 }
 
 async function* walkDir(dir: string): AsyncGenerator<string> {
@@ -28,15 +28,15 @@ async function* walkDir(dir: string): AsyncGenerator<string> {
 }
 
 function stripYamlFrontmatter(text: string): string {
-  if (!text.startsWith('---\n') && !text.startsWith('---\r\n')) {
+  if (!text.startsWith("---\n") && !text.startsWith("---\r\n")) {
     return text;
   }
 
-  const lines = text.split('\n');
+  const lines = text.split("\n");
   let endIndex = -1;
 
   for (let i = 1; i < lines.length; i++) {
-    if (lines[i].trim() === '---') {
+    if (lines[i].trim() === "---") {
       endIndex = i;
       break;
     }
@@ -46,13 +46,16 @@ function stripYamlFrontmatter(text: string): string {
     return text;
   }
 
-  return lines.slice(endIndex + 1).join('\n');
+  return lines.slice(endIndex + 1).join("\n");
 }
 
-async function getFileHash(path: string, ignoreFrontmatter: boolean = false): Promise<string> {
+async function getFileHash(
+  path: string,
+  ignoreFrontmatter: boolean = false,
+): Promise<string> {
   const file = Bun.file(path);
 
-  if (ignoreFrontmatter && path.endsWith('.md')) {
+  if (ignoreFrontmatter && path.endsWith(".md")) {
     const text = await file.text();
     const contentWithoutFrontmatter = stripYamlFrontmatter(text);
     const encoder = new TextEncoder();
@@ -66,7 +69,9 @@ async function getFileHash(path: string, ignoreFrontmatter: boolean = false): Pr
   }
 }
 
-async function readAgenticConfig(projectPath: string): Promise<AgenticConfig | null> {
+async function readAgenticConfig(
+  projectPath: string,
+): Promise<AgenticConfig | null> {
   const configPath = join(projectPath, ".opencode", "agentic.json");
 
   if (!existsSync(configPath)) {
@@ -74,14 +79,17 @@ async function readAgenticConfig(projectPath: string): Promise<AgenticConfig | n
   }
 
   try {
-    const configContent = await readFile(configPath, 'utf-8');
+    const configContent = await readFile(configPath, "utf-8");
     return JSON.parse(configContent);
   } catch {
     return null;
   }
 }
 
-export function resolveAgentModel(cliModel: string | undefined, projectPath: string): Promise<string | undefined> {
+export function resolveAgentModel(
+  cliModel: string | undefined,
+  projectPath: string,
+): Promise<string | undefined> {
   return new Promise(async (resolve) => {
     // 1. CLI parameter has highest priority
     if (cliModel) {
@@ -101,8 +109,11 @@ export function resolveAgentModel(cliModel: string | undefined, projectPath: str
   });
 }
 
-export async function processAgentTemplate(filePath: string, agentModel?: string): Promise<string> {
-  const content = await readFile(filePath, 'utf-8');
+export async function processAgentTemplate(
+  filePath: string,
+  agentModel?: string,
+): Promise<string> {
+  const content = await readFile(filePath, "utf-8");
 
   // If no agent model specified, return original content
   if (!agentModel) {
@@ -124,17 +135,25 @@ export function findAgenticInstallDir(): string {
   // The source files should be in the same directory as the bin folder
   const packageDir = dirname(binaryDir);
 
-  if (existsSync(join(packageDir, "agent")) && existsSync(join(packageDir, "command"))) {
+  if (
+    existsSync(join(packageDir, "agent")) &&
+    existsSync(join(packageDir, "command"))
+  ) {
     return packageDir;
   }
 
   // Fallback: check if we're running from local repo during development
   const localPackageDir = join(dirname(dirname(process.execPath)), "..");
-  if (existsSync(join(localPackageDir, "agent")) && existsSync(join(localPackageDir, "command"))) {
+  if (
+    existsSync(join(localPackageDir, "agent")) &&
+    existsSync(join(localPackageDir, "command"))
+  ) {
     return localPackageDir;
   }
 
-  throw new Error(`Could not find agent/command directories. Binary dir: ${binaryDir}, Package dir: ${packageDir}`);
+  throw new Error(
+    `Could not find agent/command directories. Binary dir: ${binaryDir}, Package dir: ${packageDir}`,
+  );
 }
 
 export async function findOutOfSyncFiles(
@@ -150,120 +169,152 @@ export async function findOutOfSyncFiles(
   const resolvedProjectPath = projectPath || dirname(targetPath);
 
   // Resolve the agent model with proper priority
-  const resolvedModel = await resolveAgentModel(agentModel, resolvedProjectPath);
-  
+  const resolvedModel = await resolveAgentModel(
+    agentModel,
+    resolvedProjectPath,
+  );
+
   // Directories to sync
   const dirsToSync = ["agent", "command"];
-  
+
   // Only check files from agentic source against target
   for (const dir of dirsToSync) {
     const sourceDirPath = join(sourceDir, dir);
     if (!existsSync(sourceDirPath)) continue;
-    
+
     const stats = await stat(sourceDirPath);
     if (!stats.isDirectory()) continue;
-    
+
     for await (const sourceFile of walkDir(sourceDirPath)) {
       const relativePath = sourceFile.slice(sourceDir.length + 1);
       const targetFile = join(targetPath, relativePath);
 
       if (!existsSync(targetFile)) {
-        results.push({ path: relativePath, status: 'missing' });
+        results.push({ path: relativePath, status: "missing" });
       } else {
-        if (relativePath.startsWith('agent/') && relativePath.endsWith('.md')) {
+        if (relativePath.startsWith("agent/") && relativePath.endsWith(".md")) {
           // Process agent markdown as templates before comparison
-          const sourceContent = await processAgentTemplate(sourceFile, resolvedModel);
-          const targetContent = await readFile(targetFile, 'utf-8');
+          const sourceContent = await processAgentTemplate(
+            sourceFile,
+            resolvedModel,
+          );
+          const targetContent = await readFile(targetFile, "utf-8");
 
-          const src = ignoreFrontmatter ? stripYamlFrontmatter(sourceContent) : sourceContent;
-          const dst = ignoreFrontmatter ? stripYamlFrontmatter(targetContent) : targetContent;
+          const src = ignoreFrontmatter
+            ? stripYamlFrontmatter(sourceContent)
+            : sourceContent;
+          const dst = ignoreFrontmatter
+            ? stripYamlFrontmatter(targetContent)
+            : targetContent;
 
           if (src === dst) {
-            results.push({ path: relativePath, status: 'up-to-date' });
+            results.push({ path: relativePath, status: "up-to-date" });
           } else {
-            results.push({ path: relativePath, status: 'outdated' });
+            results.push({ path: relativePath, status: "outdated" });
           }
-        } else if (relativePath.endsWith('.md') && ignoreFrontmatter) {
+        } else if (relativePath.endsWith(".md") && ignoreFrontmatter) {
           // For non-agent markdown, ignore frontmatter when comparing if requested
-          const sourceText = await readFile(sourceFile, 'utf-8');
-          const targetText = await readFile(targetFile, 'utf-8');
+          const sourceText = await readFile(sourceFile, "utf-8");
+          const targetText = await readFile(targetFile, "utf-8");
           const src = stripYamlFrontmatter(sourceText);
           const dst = stripYamlFrontmatter(targetText);
           if (src === dst) {
-            results.push({ path: relativePath, status: 'up-to-date' });
+            results.push({ path: relativePath, status: "up-to-date" });
           } else {
-            results.push({ path: relativePath, status: 'outdated' });
+            results.push({ path: relativePath, status: "outdated" });
           }
         } else {
           // Binary/other files: compare hashes
           const sourceHash = await getFileHash(sourceFile, false);
           const targetHash = await getFileHash(targetFile, false);
           if (sourceHash === targetHash) {
-            results.push({ path: relativePath, status: 'up-to-date' });
+            results.push({ path: relativePath, status: "up-to-date" });
           } else {
-            results.push({ path: relativePath, status: 'outdated' });
+            results.push({ path: relativePath, status: "outdated" });
           }
         }
       }
     }
   }
-  
+
   return results;
 }
 
-export function resolveProjectPath(providedPath?: string, useGlobal: boolean = false): string {
+export function resolveProjectPath(
+  providedPath?: string,
+  useGlobal: boolean = false,
+  configPath?: string,
+): string {
   const home = homedir();
-  
+
+  if (providedPath && configPath) {
+    console.error(
+      "Error: Cannot use a project path together with --config-dir",
+    );
+    process.exit(1);
+  }
+
   // If using global flag, return the global config directory
-  if (useGlobal) {
-    const globalDir = join(home, ".config", "opencode");
-    
+  if (useGlobal || configPath) {
+    const globalDir =
+      configPath ??
+      process.env.OPENCODE_CONFIG_DIR ??
+      join(home, ".config", "opencode");
+
     // Create the directory if it doesn't exist
     if (!existsSync(globalDir)) {
       mkdirSync(globalDir, { recursive: true });
     }
-    
+
     return globalDir;
   }
-  
+
   if (providedPath) {
     // Path was provided, check if .opencode exists
     const resolvedPath = resolve(providedPath);
     const opencodeDir = join(resolvedPath, ".opencode");
-    
+
     if (!existsSync(opencodeDir)) {
       console.error(`Error: No .opencode directory found at ${opencodeDir}`);
       process.exit(1);
     }
-    
+
     return resolvedPath;
   }
-  
+
   // No path provided, start searching from current directory
   const cwd = process.cwd();
-  
+
   // Ensure we're in a subdirectory of $HOME
   if (!cwd.startsWith(home)) {
-    console.error(`Error: Current directory is not within home directory (${home})`);
-    console.error("Automatic project detection only works within your home directory");
+    console.error(
+      `Error: Current directory is not within home directory (${home})`,
+    );
+    console.error(
+      "Automatic project detection only works within your home directory",
+    );
     process.exit(1);
   }
-  
+
   // Search upward for .opencode directory
   let currentDir = cwd;
-  
+
   while (currentDir !== home && currentDir !== "/") {
     const opencodeDir = join(currentDir, ".opencode");
-    
+
     if (existsSync(opencodeDir)) {
       return currentDir;
     }
-    
+
     currentDir = dirname(currentDir);
   }
-  
+
   // No .opencode found
-  console.error("Error: No .opencode directory found in current directory or any parent directories");
-  console.error("Please run this command from a project directory or specify a path");
+  console.error(
+    "Error: No .opencode directory found in current directory or any parent directories",
+  );
+  console.error(
+    "Please run this command from a project directory or specify a path",
+  );
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Adds support for installing and checking Agentic files against custom OpenCode configuration directories.

This makes Agentic work cleanly with isolated OpenCode configs and profile managers instead of always targeting `~/.config/opencode`.

## Changes

- Add support for `--config-dir <path>`
- Respect `OPENCODE_CONFIG_DIR`
- Preserve `~/.config/opencode` as the default fallback
- Apply the same behavior to both `pull` and `status`
- Update documentation and usage examples

Config directory resolution now follows:

```text
--config-dir
↓
OPENCODE_CONFIG_DIR
↓
~/.config/opencode
````

## Example

```bash
agentic pull --config-dir ~/.config/opencode/profiles/agentic
agentic status --config-dir ~/.config/opencode/profiles/agentic
```

Or using OpenCode's environment variable:

```bash
export OPENCODE_CONFIG_DIR="$HOME/.config/opencode/profiles/agentic"
agentic pull -g
```

## Motivation

OpenCode supports custom configuration directories through `OPENCODE_CONFIG_DIR`, but Agentic previously hardcoded global operations to `~/.config/opencode`.

Supporting custom config directories allows Agentic to integrate more naturally with profile managers, isolated configurations, testing environments, and other non-default OpenCode setups.

## Compatibility

Existing behavior remains unchanged when neither `--config-dir` nor `OPENCODE_CONFIG_DIR` is provided.